### PR TITLE
Update kafka-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "kafka-node": "~0.2.1"
+    "kafka-node": "^4.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current dependency version does not compile on node version >8. I have updated to kafka-node 4.1.3